### PR TITLE
Update crt-tf-provider-setup-no-svr.json

### DIFF
--- a/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup-no-svr.json
+++ b/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup-no-svr.json
@@ -14,7 +14,6 @@
     },
     "ParameterSSHFingerprint": {
       "Description": "TerraformSSHFingerprintParameter",
-      "Type": "String"
     },
     "ParameterSSHHost": {
       "Description": "TerraformSSHHostParameter must be internet accessable",
@@ -96,7 +95,7 @@
           ]
         },
         "Timeout": 240,
-        "Runtime": "python2.7"
+        "Runtime": "python3.9"
       }
     },
     "CopyFromSourceRun": {


### PR DESCRIPTION
Deployment fails with " Resource handler returned message: "The runtime parameter of python2.7 is no longer supported for creating or updating AWS Lambda functions.".  I changed to 3.9 and deployed successfully, but didn't do any further testing.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
