### PR TITLE
Update crt-tf-provider-setup.json

### DIFF
--- a/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup.json
+++ b/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup.json
@@ -623,7 +623,7 @@
                     ]
                 }, 
                 "Timeout": 240, 
-                "Runtime": "python2.7"
+                "Runtime": "python3.9"
             }
         }, 
         "HoldingBucket": {


### PR DESCRIPTION
Deployment fails with " Resource handler returned message: "The runtime parameter of python2.7 is no longer supported for creating or updating AWS Lambda functions.".  I changed to 3.9 and deployed successfully, but didn't do any further testing.

Same change as the other submitted pull request for the no-svr.

Not sure why github is adding the change on the last line.  Something to do with editing in the browser.  You only need to change the python version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
