### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/CloudFormation-ResourceType-Provider-Terraform/bits/crt-tf-provider-setup_ubuntu.json
+++ b/CloudFormation-ResourceType-Provider-Terraform/bits/crt-tf-provider-setup_ubuntu.json
@@ -219,7 +219,7 @@
           ]
         },
         "Timeout": 300,
-        "Runtime": "python3.7"
+        "Runtime": "python3.10"
       }
     },
     "CRproviderRegRoleDefine": {

--- a/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup-no-svr.json
+++ b/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup-no-svr.json
@@ -178,7 +178,7 @@
           ]
         },
         "Timeout": 300,
-        "Runtime": "python3.7"
+        "Runtime": "python3.10"
       }
     },
     "CrproviderRegRoleDefine": {

--- a/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup.json
+++ b/CloudFormation-ResourceType-Provider-Terraform/templates/cs/crt-tf-provider-setup.json
@@ -523,7 +523,7 @@
                     ]
                 }, 
                 "Timeout": 300, 
-                "Runtime": "python3.7"
+                "Runtime": "python3.10"
             }, 
             "DependsOn": "CopyFromSourceRun"
         }, 


### PR DESCRIPTION
CloudFormation templates in aws-service-catalog-terraform-reference-architecture have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.